### PR TITLE
FapCrunch_enable_compilation_on_macos_silicon

### DIFF
--- a/src/FapCrunch/YmLoad.cpp
+++ b/src/FapCrunch/YmLoad.cpp
@@ -10,6 +10,10 @@
 #ifdef _MSC_VER
 #define bswap_16(x) _byteswap_ushort(x)
 #define bswap_32(x) _byteswap_ulong(x)
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>  
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
 #else
 #include <byteswap.h>
 #endif
@@ -96,7 +100,7 @@ bool YmLoad::load(const char* fileName)
 	fclose(in);
 
 	//---------------------------------------------------
-	// Lecture des donn‚es YM:
+	// Lecture des donn?es YM:
 	//---------------------------------------------------
 	if (!ymDecode())
 	{

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,10 @@
 RASM = rasm
-FAP_CRUNCH = $(BUILD_DIR)/FapCrunchLin
+
+ifeq "$(shell uname)" "Darwin" 
+ FAP_CRUNCH = $(BUILD_DIR)/FapCrunchMac
+ else
+ FAP_CRUNCH = $(BUILD_DIR)/FapCrunchLin
+endif
 
 #
 # Define directories
@@ -13,7 +18,11 @@ EXAMPLE_DIR = Example
 #
 TEST_TARGET = FapTest
 PLAYER_TARGET = $(BUILD_DIR)/fap-play.bin
-CRUNCHER_TARGET = $(BUILD_DIR)/FapCrunchLin
+ifeq "$(shell uname)" "Darwin" 
+ CRUNCHER_TARGET = $(BUILD_DIR)/FapCrunchMac
+ else
+ CRUNCHER_TARGET = $(BUILD_DIR)/FapCrunchLin
+endif
 RELEASE_TARGET = FapRelease.zip
 
 #


### PR DESCRIPTION
Added basic test in Makefile for macOS detection (uname = Darwin) to adapt
filename to FapCrunchMac.

Added test to YmLoad.cpp to check for macOS and define correct byteswap headers for
macOS silicon.

This should allow macOS silicon users to compile FapCrunch also on their machine.