### PR TITLE
Corrected the missing output file not being closed.

### DIFF
--- a/src/FapCrunch/FapCrunch.cpp
+++ b/src/FapCrunch/FapCrunch.cpp
@@ -125,6 +125,8 @@ bool WriteFile(char* fileName,
 	long fileSize = ftell(out);
 	printf("  - File size: %ld (0x%lX)\n", fileSize, fileSize);
 
+	fclose(out);
+	
 	return true;
 }
 


### PR DESCRIPTION
The output file was not closed, which provoked a 0-byte sized output file on MacOsX.